### PR TITLE
Jump to Section 5 even if it follows directly after Section 1 or 2

### DIFF
--- a/pymetdecoder/synop/__init__.py
+++ b/pymetdecoder/synop/__init__.py
@@ -131,7 +131,7 @@ class SYNOP(pymetdecoder.Report):
             # Parse the next group, based on the group header
             for i in range(1, 10):
                 try:
-                    if not re.match("^(222|333)", next_group):
+                    if not re.match("^(222|333|444|555)", next_group):
                         header = int(next_group[0:1])
                     else:
                         header = None
@@ -226,7 +226,7 @@ class SYNOP(pymetdecoder.Report):
             if has_section_2:
                 for i in range(0, 9):
                     try:
-                        if not re.match("^(ICE|333)$", next_group):
+                        if not re.match("^(ICE|333|444|555)$", next_group):
                             header = int(next_group[0:1])
                         else:
                             header = None

--- a/pymetdecoder/tests/test_synop.py
+++ b/pymetdecoder/tests/test_synop.py
@@ -892,6 +892,59 @@ class TestSynopBBXXAlternative(BaseTestSynop):
             "text": "icy conditions"
         }
     }
+class TestSynopAAXXSection5AfterSection1(BaseTestSynop):
+    """
+    Tests that section 5 groups are added to the "section5" key even if it follows
+    directly after section 1
+    """
+    SYNOP = "AAXX 25064 04018 42589 43120 555 3//32 84619"
+    expected = {
+        'station_type': {'value': 'AAXX'},
+        'obs_time': {
+            'day': {'value': 25}, 'hour': {'value': 6}},
+            'wind_indicator': {'value': 4, 'unit': 'KT', 'estimated': False},
+            'station_id': {'value': '04018'},
+            'region': {'value': 'VI'},
+            'precipitation_indicator': {
+                'value': 4, 'in_group_1': False, 'in_group_3': False
+            },
+        'weather_indicator': {'value': 2, 'automatic': False},
+        'lowest_cloud_base': {
+            '_table': '1600',
+            'min': 600,
+            'max': 1000,
+            'quantifier': None,
+            '_code': 5,
+            'unit': 'm'
+        },
+        'visibility': {
+            '_table': '4377',
+            'value': 70000,
+            'quantifier': 'isGreater',
+            'use90': False,
+            '_code': 89,
+            'unit': 'm'
+        },
+        'cloud_cover': {
+            '_table': '2700',
+            'value': 4,
+            'obscured': False,
+            'unit': 'okta',
+            '_code': 4
+        },
+        'surface_wind': {
+            'direction': {
+                '_table': '0877',
+                'value': 310,
+                'varAllUnknown': False,
+                'calm': False,
+                '_code': 31,
+                'unit': 'deg'
+            },
+            'speed': {'value': 20, 'unit': 'KT'}
+        },
+        'section5': ['3//32', '84619']
+    }
 class TestSynopException:
     """
     Tests the various exceptions


### PR DESCRIPTION
When Section 5 follows directly after Section 1 (or 2), the decoder did not recognize that and instead decoded Section 5 groups as Section 1 groups. For example, in this SYNOP:

`AAXX 25064 04018 42589 43120 10005 555 3//32 84619`

the `84619` group was incorrectly picked up as a cloud type group and both Section 5 groups were not added to the `'section5'` attribute of the output.