### PR TITLE
add missing import

### DIFF
--- a/pymetdecoder/synop/observations.py
+++ b/pymetdecoder/synop/observations.py
@@ -15,6 +15,7 @@
 # CONFIGURATION
 ################################################################################
 import re, warnings
+import pymetdecoder
 from pymetdecoder import Observation, logging, DecodeError, EncodeError, InvalidCode
 from pymetdecoder import code_tables as ct
 ################################################################################


### PR DESCRIPTION
Warnings were changed from

```python
logging.warning("Cloud cover (Nh = {}) reported, but there are no low or middle clouds (CL = {}, CM = {})".format(Nh, CL, CM))
```
to
```python
warnings.warn("Cloud cover (Nh = {}) reported, but there are no low or middle clouds (CL = {}, CM = {})".format(Nh, CL, CM), pymetdecoder.DecodeWarning)
```
creating a dependency on module `pymetdecoder`, but the module was never imported.